### PR TITLE
Wait for requests to finish on flush

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -1,15 +1,14 @@
 package analytics
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"strconv"
 	"sync"
-
-	"bytes"
-	"encoding/json"
-	"net/http"
 	"time"
 )
 
@@ -328,7 +327,6 @@ func (c *client) loop() {
 	defer close(c.shutdown)
 
 	wg := &sync.WaitGroup{}
-	defer wg.Wait()
 
 	tick := time.NewTicker(c.Interval)
 	defer tick.Stop()
@@ -360,6 +358,7 @@ func (c *client) loop() {
 			}
 
 			c.flush(&mq, wg, ex)
+			wg.Wait()
 			c.debugf("exit")
 			return
 		}


### PR DESCRIPTION
This helps guarantee that all requests are made when the quit signal is received. The previous wg.Done() did nothing since it was deferred.